### PR TITLE
Oracle Daemon Metrics Update

### DIFF
--- a/ckn_broker/neo4jsink-oracle-events-connector.json
+++ b/ckn_broker/neo4jsink-oracle-events-connector.json
@@ -15,32 +15,6 @@
     "neo4j.server.uri": "bolt://neo4j:7687",
     "neo4j.authentication.basic.username": "neo4j",
     "neo4j.authentication.basic.password": "PWD_HERE",
-    "neo4j.topic.cypher.oracle-events": "
-      MERGE (device:EdgeDevice {device_id: event.device_id})
-      MERGE (ex:Experiment {experiment_id: event.experiment_id}) ON CREATE SET ex.start_time = timestamp()
-      MERGE (depl:Deployment {deployment_id: event.experiment_id}) ON CREATE SET depl.start_time = timestamp()
-      MERGE (user:User {user_id: event.user_id})
-      MERGE (user)<-[exr:SUBMITTED_BY]-(ex) ON CREATE SET exr.submitted_time = timestamp()
-      MERGE (device)<-[dex:EXECUTED_ON]-(ex) ON CREATE SET dex.submitted_time = timestamp()
-      MERGE (device)<-[ddepl:DEPLOYED_IN]-(depl)
-      MERGE (model:Model {model_id: event.model_id})
-      MERGE (model)<-[mdex:USED]-(ex) ON CREATE SET mdex.start_time = timestamp()
-      MERGE (model)-[hd:HAS_DEPLOYMENT]->(depl)
-      MERGE (ri:RawImage {UUID: event.UUID})
-      ON CREATE SET
-        ri.image_name = event.image_name,
-        ri.ground_truth = event.ground_truth
-      MERGE (ex)<-[r:PROCESSED_BY]-(ri)
-      SET r = {
-        image_count: event.image_count,
-        image_receiving_timestamp: datetime(event.image_receiving_timestamp),
-        image_scoring_timestamp: datetime(event.image_scoring_timestamp),
-        model_id: event.model_id,
-        scores: event.flattened_scores,
-        image_store_delete_time: datetime(event.image_store_delete_time),
-        image_decision: event.image_decision,
-        ingestion_timestamp: datetime()
-      }
-    "
+    "neo4j.topic.cypher.oracle-events": "MERGE (device:EdgeDevice {device_id: event.device_id})\nMERGE (ex:Experiment {experiment_id: event.experiment_id})\n  ON CREATE SET ex.start_time = timestamp()\nMERGE (depl:Deployment {deployment_id: event.experiment_id})\n  ON CREATE SET depl.start_time = timestamp()\nMERGE (user:User {user_id: event.user_id})\nMERGE (user)<-[exr:SUBMITTED_BY]-(ex)\n  ON CREATE SET exr.submitted_time = timestamp()\nMERGE (device)<-[dex:EXECUTED_ON]-(ex)\n  ON CREATE SET dex.submitted_time = timestamp()\nMERGE (device)<-[ddepl:DEPLOYED_IN]-(depl)\nMERGE (model:Model {model_id: event.model_id})\nMERGE (model)<-[mdex:USED]-(ex)\n  ON CREATE SET mdex.start_time = timestamp()\nMERGE (model)-[hd:HAS_DEPLOYMENT]->(depl)\nMERGE (ri:RawImage {UUID: event.UUID})\n  ON CREATE SET ri.image_name = event.image_name,\n                ri.ground_truth = event.ground_truth\nMERGE (ex)<-[r:PROCESSED_BY]-(ri)\n  ON CREATE SET r.image_count = event.image_count,\n                r.image_receiving_timestamp = datetime(event.image_receiving_timestamp),\n                r.image_scoring_timestamp = datetime(event.image_scoring_timestamp),\n                r.model_id = event.model_id,\n                r.scores = event.flattened_scores,\n                r.image_store_delete_time = datetime(event.image_store_delete_time),\n                r.image_decision = event.image_decision,\n                r.label = event.label,\n                r.probability = event.probability,\n                r.ingestion_timestamp = datetime()\nSET ex.total_images = event.total_images,\n    ex.total_predictions = event.total_predictions,\n    ex.total_ground_truth_objects = event.total_ground_truth_objects,\n    ex.true_positives = event.true_positives,\n    ex.false_positives = event.false_positives,\n    ex.false_negatives = event.false_negatives,\n    ex.precision = event.precision,\n    ex.recall = event.recall,\n    ex.f1_score = event.f1_score,\n    ex.mean_iou = event.mean_iou,\n    ex.map_50 = event.map_50,\n    ex.map_50_95 = event.map_50_95"
   }
 }

--- a/ckn_dashboard/requirements.txt
+++ b/ckn_dashboard/requirements.txt
@@ -1,5 +1,4 @@
 pandas~=2.2.2
-numpy>=1.23.2
 neo4j~=5.22.0
 streamlit~=1.36.0
 python-dotenv~=1.0.1

--- a/plugins/oracle_ckn_daemon/Dockerfile
+++ b/plugins/oracle_ckn_daemon/Dockerfile
@@ -8,4 +8,5 @@ COPY requirements.txt /app/
 
 RUN pip install -r /app/requirements.txt
 
-ENTRYPOINT [ "python", "-u", "/app/daemon.py"]
+# Default to running the daemon, but can be overridden
+CMD [ "python", "-u", "/app/daemon.py"]

--- a/plugins/oracle_ckn_daemon/README.md
+++ b/plugins/oracle_ckn_daemon/README.md
@@ -1,14 +1,21 @@
 # CKN Daemon for TAPIS Camera Traps Application
 CKN Daemon for extracting camera traps performance information from the Edge to the Cloud. 
 
+This daemon includes both Oracle event processing and experiment metrics computation in a single integrated service:
+- **Oracle CKN Daemon**: Processes image events and sends them to Kafka
+- **Experiment Metrics Service**: Runs in a background thread, periodically computing comprehensive object detection metrics and updating Experiment nodes in Neo4j 
+
 ### Usage
 
-1. Go to the root directory and run `make run`. Refer [here](../../README.md) for more details.
+1. Go to the root directory and run `make up`. Refer [here](../../README.md) for more details.
 
-2. To start CKN-Oracle Daemon, run:
+2. To start the integrated CKN-Oracle Daemon (includes experiment metrics service), run:
    ```bash
    docker compose -f docker-compose.yml up -d --build
    ```
+   
+   This will start one container:
+   - `ckn-oracle-daemon`: Processes image events and runs experiment metrics computation in background
 
 3. To produce events, run:
    ```bash
@@ -20,7 +27,7 @@ CKN Daemon for extracting camera traps performance information from the Edge to 
    MATCH (n) RETURN n
    ```
 
-5. To stop CKN-Oracle Daemon, run:
+5. To stop the integrated service, run:
    ```bash
    docker compose -f docker-compose.yml down
    ```
@@ -32,17 +39,38 @@ Docker image for the CKN Daemon for Cameratraps is available at:
 
 [D2I Docker Repository](https://hub.docker.com/repository/docker/iud2i/ckn-daemon-cameratraps/general)
 
-The following environment variables can be set during experiment execution time.
+### Environment Variables
 
-      - ORACLE_CSV_PATH=/oracle_logs/image_mapping_final.json
-      - CKN_LOG_FILE=/oracle_logs/ckn.log
-      - CKN_KAFKA_BROKER=localhost:9092
-      - CKN_KAFKA_TOPIC=oracle-events
-      - CAMERA_TRAPS_DEVICE_ID=device_1
-      - USER_ID=swithana
-      - EXPERIMENT_ID=experiment_1
-      - EXPERIMENT_END_SIGNAL = 6e153711-9823-4ee6-b608-58e2e801db51
-      - POWER_SUMMARY_FILE=/power_logs/power_summary_report.json
-      - POWER_SUMMARY_TOPIC=cameratraps-power-summary
-      - POWER_SUMMARY_TIMOUT=10
-      - POWER_SUMMARY_MAX_TRIES=5
+The following environment variables can be set during experiment execution time:
+
+**Oracle CKN Daemon:**
+- `ORACLE_CSV_PATH=/oracle_logs/image_mapping_final.json`
+- `CKN_LOG_FILE=/oracle_logs/ckn.log`
+- `CKN_KAFKA_BROKER=localhost:9092`
+- `CKN_KAFKA_TOPIC=oracle-events`
+- `CAMERA_TRAPS_DEVICE_ID=device_1`
+- `USER_ID=swithana`
+- `EXPERIMENT_ID=experiment_1`
+- `EXPERIMENT_END_SIGNAL=6e153711-9823-4ee6-b608-58e2e801db51`
+- `POWER_SUMMARY_FILE=/power_logs/power_summary_report.json`
+- `POWER_SUMMARY_TOPIC=cameratraps-power-summary`
+- `POWER_SUMMARY_TIMOUT=10`
+- `POWER_SUMMARY_MAX_TRIES=5`
+
+
+### Experiment Metrics
+
+The integrated Experiment Metrics Service automatically computes and updates Experiment nodes with comprehensive object detection metrics every 5 minutes:
+
+- `total_images`: Number of images processed
+- `mean_iou`: Mean Intersection over Union (using confidence scores as proxy)
+- `total_ground_truth_objects`: Number of ground truth objects
+- `total_predictions`: Total number of predictions made
+- `false_positives`: Number of false positive predictions
+- `true_positives`: Number of true positive predictions
+- `false_negatives`: Number of false negative predictions
+- `precision`: Precision score
+- `recall`: Recall score
+- `f1_score`: F1 score
+- `map_50`: Mean Average Precision at IoU=0.5
+- `map_50_95`: Mean Average Precision averaged over IoU thresholds 0.5-0.95

--- a/plugins/oracle_ckn_daemon/daemon.py
+++ b/plugins/oracle_ckn_daemon/daemon.py
@@ -39,6 +39,221 @@ class OracleEventHandler(FileSystemEventHandler):
         self.user_id = user_id
         self.processed_images = set()
         self.stop_daemon = False
+        # Running experiment-level metrics
+        self.metrics = {
+            "total_images": 0,
+            "total_predictions": 0,
+            "total_ground_truth_objects": 0,
+            "true_positives": 0,
+            "false_positives": 0,
+            "false_negatives": 0,
+            "precision": 0.0,
+            "recall": 0.0,
+            "f1_score": 0.0,
+            "mean_iou": None,
+            "map_50": None,
+            "map_50_95": None,
+            # Internal accumulators for IoU/mAP
+            "sum_iou": 0.0,
+            "num_iou_pairs": 0,
+            "gt_boxes_count": 0,
+        }
+        # For mAP: keep per-threshold prediction lists of (score, is_tp)
+        self.map_thresholds = [round(t, 2) for t in [0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95]]
+        self.map_data = {t: [] for t in self.map_thresholds}
+
+    def _compute_iou(self, box_a, box_b):
+        """
+        Compute IoU between two boxes in [x, y, w, h] format with normalized coordinates.
+        """
+        ax, ay, aw, ah = box_a
+        bx, by, bw, bh = box_b
+        ax2, ay2 = ax + aw, ay + ah
+        bx2, by2 = bx + bw, by + bh
+        inter_x1 = max(ax, bx)
+        inter_y1 = max(ay, by)
+        inter_x2 = min(ax2, bx2)
+        inter_y2 = min(ay2, by2)
+        inter_w = max(0.0, inter_x2 - inter_x1)
+        inter_h = max(0.0, inter_y2 - inter_y1)
+        inter_area = inter_w * inter_h
+        area_a = max(0.0, aw) * max(0.0, ah)
+        area_b = max(0.0, bw) * max(0.0, bh)
+        union = area_a + area_b - inter_area
+        return (inter_area / union) if union > 0 else 0.0
+
+    def _greedy_match(self, preds, gts, iou_threshold):
+        """
+        Greedy 1-1 matching between predictions and ground truths by IoU threshold.
+        Returns list of (pred_idx, gt_idx, iou) for matches.
+        """
+        matches = []
+        used_preds = set()
+        used_gts = set()
+        # Precompute IoU matrix
+        iou_matrix = []
+        for pi, p in enumerate(preds):
+            pbox = p.get("bounding_box")
+            prow = []
+            for gi, g in enumerate(gts):
+                gbox = g.get("bounding_box")
+                iou = self._compute_iou(pbox, gbox)
+                prow.append((gi, iou))
+            iou_matrix.append((pi, prow))
+        # Iterate by descending IoU candidates
+        candidates = []
+        for pi, prow in iou_matrix:
+            for gi, iou in prow:
+                candidates.append((iou, pi, gi))
+        candidates.sort(reverse=True)
+        for iou, pi, gi in candidates:
+            if iou < iou_threshold:
+                break
+            if pi in used_preds or gi in used_gts:
+                continue
+            matches.append((pi, gi, iou))
+            used_preds.add(pi)
+            used_gts.add(gi)
+        return matches, used_preds, used_gts
+
+    def _update_map_structures(self, predictions, gt_boxes):
+        """
+        Update per-threshold AP structures using label-aware matches.
+        """
+        for thr in self.map_thresholds:
+            matches, used_preds, used_gts = self._greedy_match(predictions, gt_boxes, thr)
+            # Label-aware: only count as TP if labels match
+            matched_gt_by_pred = {pi: gi for pi, gi, _ in matches}
+            for pi, pred in enumerate(predictions):
+                score = float(pred.get("probability", 0.0))
+                if pi in matched_gt_by_pred:
+                    gi = matched_gt_by_pred[pi]
+                    if str(pred.get("label")) == str(gt_boxes[gi].get("label")):
+                        self.map_data[thr].append((score, True))
+                    else:
+                        self.map_data[thr].append((score, False))
+                else:
+                    self.map_data[thr].append((score, False))
+
+    def _compute_ap(self, preds_list, num_gt):
+        """
+        Compute AP given list of (score, is_tp) and total GT count.
+        Uses standard 11-point interpolation-like precision envelope integration.
+        """
+        if num_gt <= 0 or not preds_list:
+            return 0.0
+        # Sort by score desc
+        preds_sorted = sorted(preds_list, key=lambda x: x[0], reverse=True)
+        tp_cum = 0
+        fp_cum = 0
+        precisions = []
+        recalls = []
+        for score, is_tp in preds_sorted:
+            if is_tp:
+                tp_cum += 1
+            else:
+                fp_cum += 1
+            precision = tp_cum / max(tp_cum + fp_cum, 1)
+            recall = tp_cum / num_gt
+            precisions.append(precision)
+            recalls.append(recall)
+        # Precision envelope
+        for i in range(len(precisions) - 2, -1, -1):
+            if precisions[i] < precisions[i + 1]:
+                precisions[i] = precisions[i + 1]
+        # Integrate AP over recall from 0 to 1 based on observed points
+        ap = 0.0
+        prev_recall = 0.0
+        for p, r in zip(precisions, recalls):
+            if r > prev_recall:
+                ap += p * (r - prev_recall)
+                prev_recall = r
+        return ap
+
+    def _update_experiment_metrics(self, ground_truth_label, scores_list, ground_truth_boxes=None):
+        """
+        Update running experiment metrics based on a single image's ground truth label and predictions.
+        If ground-truth bounding boxes are provided as a list of {label, bounding_box}, compute IoU and mAP.
+        """
+        # Normalize inputs
+        gt = None if ground_truth_label is None else str(ground_truth_label)
+        has_gt_object = gt is not None and gt.lower() not in ["empty", "unknown"]
+
+        predictions = scores_list if isinstance(scores_list, list) else []
+        num_predictions = len(predictions)
+        predicted_labels = [str(p.get("label")) for p in predictions if p and p.get("label") is not None]
+
+        # If GT boxes exist, use detection-based accounting; else use classification fallback
+        detection_mode = isinstance(ground_truth_boxes, list) and len(ground_truth_boxes) > 0
+        increment_true_positive = 0
+        increment_false_negative = 0
+        increment_false_positive = 0
+        if detection_mode:
+            # Ensure GT boxes have label and bounding_box
+            gt_boxes = [g for g in ground_truth_boxes if g and g.get("bounding_box") is not None]
+            self.metrics["gt_boxes_count"] += len(gt_boxes)
+            # Update mAP structures
+            self._update_map_structures(predictions, gt_boxes)
+            # Compute matches at IoU 0.5 for TP/FP/FN and IoU accumulation
+            matches, used_preds, used_gts = self._greedy_match(predictions, gt_boxes, 0.5)
+            # Label-aware TP
+            tp_count = 0
+            sum_iou_img = 0.0
+            for pi, gi, iou in matches:
+                if str(predictions[pi].get("label")) == str(gt_boxes[gi].get("label")):
+                    tp_count += 1
+                    sum_iou_img += iou
+            fp_count = max(num_predictions - len(used_preds), 0)
+            fn_count = max(len(gt_boxes) - len(used_gts), 0)
+            increment_true_positive = tp_count
+            increment_false_positive = fp_count
+            increment_false_negative = fn_count
+            # Update IoU accumulators
+            if tp_count > 0:
+                self.metrics["sum_iou"] += sum_iou_img
+                self.metrics["num_iou_pairs"] += tp_count
+        else:
+            # Classification-based TP/FP/FN (1 GT object at most per image in current data)
+            has_correct_prediction = has_gt_object and any(lbl == gt for lbl in predicted_labels)
+            increment_true_positive = 1 if has_correct_prediction else 0
+            increment_false_negative = 1 if has_gt_object and not has_correct_prediction else 0
+            increment_false_positive = max(num_predictions - (1 if has_correct_prediction else 0), 0)
+
+        # Update totals
+        self.metrics["total_images"] += 1
+        self.metrics["total_predictions"] += num_predictions
+        if detection_mode:
+            self.metrics["total_ground_truth_objects"] += len(ground_truth_boxes)
+        else:
+            self.metrics["total_ground_truth_objects"] += 1 if has_gt_object else 0
+        self.metrics["true_positives"] += increment_true_positive
+        self.metrics["false_negatives"] += increment_false_negative
+        self.metrics["false_positives"] += increment_false_positive
+
+        # Derived metrics
+        tp = float(self.metrics["true_positives"]) 
+        fp = float(self.metrics["false_positives"]) 
+        fn = float(self.metrics["false_negatives"]) 
+        precision = (tp / (tp + fp)) if (tp + fp) > 0 else 0.0
+        recall = (tp / (tp + fn)) if (tp + fn) > 0 else 0.0
+        f1 = (2.0 * precision * recall / (precision + recall)) if (precision + recall) > 0 else 0.0
+        self.metrics["precision"] = precision
+        self.metrics["recall"] = recall
+        self.metrics["f1_score"] = f1
+        # Mean IoU
+        if self.metrics["num_iou_pairs"] > 0:
+            self.metrics["mean_iou"] = self.metrics["sum_iou"] / self.metrics["num_iou_pairs"]
+        # mAP@0.5 and mAP@0.5:0.95 using accumulated predictions
+        if self.metrics["gt_boxes_count"] > 0:
+            # AP at 0.5
+            ap50 = self._compute_ap(self.map_data[0.5], self.metrics["gt_boxes_count"]) if 0.5 in self.map_data else 0.0
+            # Mean AP across thresholds
+            ap_values = []
+            for t in self.map_thresholds:
+                ap_values.append(self._compute_ap(self.map_data[t], self.metrics["gt_boxes_count"]))
+            map_50_95 = sum(ap_values) / len(ap_values) if ap_values else 0.0
+            self.metrics["map_50"] = ap50
+            self.metrics["map_50_95"] = map_50_95
 
     def on_deleted(self, event):
         pass
@@ -89,6 +304,7 @@ class OracleEventHandler(FileSystemEventHandler):
             image_count = value.get("image_count")
             image_name = value.get("image_name")
             ground_truth = value.get("ground_truth")
+            ground_truth_boxes = value.get("ground_truth_boxes") or value.get("ground_truth_bboxes")
             image_receiving_timestamp = value.get("image_receiving_timestamp")
             image_scoring_timestamp = value.get("image_scoring_timestamp")
             image_store_delete_time = value.get("image_store_delete_time", value.get("image_delete_time"))
@@ -109,7 +325,10 @@ class OracleEventHandler(FileSystemEventHandler):
                 probability = 0
                 flattened_scores = None
 
-            # Generate the event
+            # Update experiment metrics (include GT boxes if available)
+            self._update_experiment_metrics(ground_truth, scores, ground_truth_boxes)
+
+            # Generate the event (include running experiment metrics)
             event = {
                 "image_count": image_count,
                 "UUID": uuid,
@@ -122,7 +341,20 @@ class OracleEventHandler(FileSystemEventHandler):
                 "probability": probability,
                 "image_store_delete_time": image_store_delete_time,
                 "image_decision": image_decision,
-                "flattened_scores": flattened_scores
+                "flattened_scores": flattened_scores,
+                # Running totals for the experiment at the moment of this event
+                "total_images": self.metrics["total_images"],
+                "total_predictions": self.metrics["total_predictions"],
+                "total_ground_truth_objects": self.metrics["total_ground_truth_objects"],
+                "true_positives": self.metrics["true_positives"],
+                "false_positives": self.metrics["false_positives"],
+                "false_negatives": self.metrics["false_negatives"],
+                "precision": self.metrics["precision"],
+                "recall": self.metrics["recall"],
+                "f1_score": self.metrics["f1_score"],
+                "mean_iou": self.metrics["mean_iou"],
+                "map_50": self.metrics["map_50"],
+                "map_50_95": self.metrics["map_50_95"],
             }
             self.produce_event(event)
 
@@ -231,6 +463,7 @@ if __name__ == "__main__":
     logging.info(f"Watching file: {ORACLE_EVENTS_FILE}")
     observer.start()
 
+
     try:
         while not event_handler.stop_daemon:
             time.sleep(1)
@@ -240,6 +473,7 @@ if __name__ == "__main__":
     # wait for oracle thread to finish
     observer.stop()
     observer.join()
+    
 
     if ENABLE_POWER_MONITORING != 'false':
         # Experiment is shutting down. Streaming power information before shutting down.

--- a/plugins/oracle_ckn_daemon/events/image_mapping_final.json
+++ b/plugins/oracle_ckn_daemon/events/image_mapping_final.json
@@ -10,7 +10,8 @@
     "score": [
       {
         "label": "vehicle",
-        "probability": 0.005289999768137932
+        "probability": 0.005289999768137932,
+        "bounding_box": [0.35, 0.45, 0.20, 0.25]
       }
     ],
     "image_delete_time": "2024-08-06T20:34:28.910339666+00:00",
@@ -27,7 +28,8 @@
     "score": [
       {
         "label": "animal",
-        "probability": 0.9240000247955322
+        "probability": 0.9240000247955322,
+        "bounding_box": [0.35, 0.45, 0.20, 0.25]
       }
     ],
     "image_store_delete_time": "2024-08-06T20:34:47.438858883+00:00",
@@ -44,27 +46,33 @@
     "score": [
       {
         "label": "vehicle",
-        "probability": 0.005119999870657921
+        "probability": 0.005119999870657921,
+        "bounding_box": [0.35, 0.45, 0.20, 0.25]
       },
       {
         "label": "vehicle",
-        "probability": 0.005950000137090683
+        "probability": 0.005950000137090683,
+        "bounding_box": [0.35, 0.45, 0.20, 0.25]
       },
       {
         "label": "vehicle",
-        "probability": 0.008919999934732914
+        "probability": 0.008919999934732914,
+        "bounding_box": [0.35, 0.45, 0.20, 0.25]
       },
       {
         "label": "vehicle",
-        "probability": 0.01209999993443489
+        "probability": 0.01209999993443489,
+        "bounding_box": [0.35, 0.45, 0.20, 0.25]
       },
       {
         "label": "vehicle",
-        "probability": 0.015300000086426735
+        "probability": 0.015300000086426735,
+        "bounding_box": [0.35, 0.45, 0.20, 0.25]
       },
       {
         "label": "vehicle",
-        "probability": 0.08139999955892563
+        "probability": 0.08139999955892563,
+        "bounding_box": [0.35, 0.45, 0.20, 0.25]
       }
     ],
     "image_delete_time": "2024-08-06T20:35:05.364311669+00:00",
@@ -81,11 +89,13 @@
     "score": [
       {
         "label": "animal",
-        "probability": 0.005950000137090683
+        "probability": 0.005950000137090683,
+        "bounding_box": [0.35, 0.45, 0.20, 0.25]
       },
       {
         "label": "animal",
-        "probability": 0.008100000210106373
+        "probability": 0.008100000210106373,
+        "bounding_box": [0.15, 0.22, 0.18, 0.31]
       }
     ],
     "image_delete_time": "2024-08-06T20:35:24.076661137+00:00",
@@ -102,19 +112,23 @@
     "score": [
       {
         "label": "animal",
-        "probability": 0.007000000216066837
+        "probability": 0.007000000216066837,
+        "bounding_box": [0.42, 0.38, 0.16, 0.29]
       },
       {
         "label": "animal",
-        "probability": 0.010300000198185444
+        "probability": 0.010300000198185444,
+        "bounding_box": [0.28, 0.51, 0.24, 0.19]
       },
       {
         "label": "animal",
-        "probability": 0.015599999576807022
+        "probability": 0.015599999576807022,
+        "bounding_box": [0.61, 0.33, 0.22, 0.36]
       },
       {
         "label": "animal",
-        "probability": 0.09179999679327011
+        "probability": 0.09179999679327011,
+        "bounding_box": [0.19, 0.64, 0.31, 0.14]
       }
     ],
     "image_delete_time": "2024-08-06T20:35:43.001081923+00:00",
@@ -131,7 +145,8 @@
     "score": [
       {
         "label": "empty",
-        "probability": 0.0
+        "probability": 0.0,
+        "bounding_box": [0.47, 0.29, 0.26, 0.42]
       }
     ],
     "image_delete_time": "2024-08-06T20:36:01.485590626+00:00",
@@ -148,7 +163,8 @@
     "score": [
       {
         "label": "empty",
-        "probability": 0.0
+        "probability": 0.0,
+        "bounding_box": [0.33, 0.58, 0.19, 0.27]
       }
     ],
     "image_delete_time": "2024-08-06T20:36:19.564788426+00:00",
@@ -165,7 +181,8 @@
     "score": [
       {
         "label": "animal",
-        "probability": 0.9549999833106995
+        "probability": 0.9549999833106995,
+        "bounding_box": [0.52, 0.16, 0.28, 0.39]
       }
     ],
     "image_store_delete_time": "2024-08-06T20:36:36.992538295+00:00",
@@ -182,7 +199,8 @@
     "score": [
       {
         "label": "animal",
-        "probability": 0.7059999704360962
+        "probability": 0.7059999704360962,
+        "bounding_box": [0.38, 0.43, 0.17, 0.34]
       }
     ],
     "image_store_delete_time": "2024-08-06T20:36:56.641497680+00:00",
@@ -199,43 +217,53 @@
     "score": [
       {
         "label": "human",
-        "probability": 0.005160000175237656
+        "probability": 0.005160000175237656,
+        "bounding_box": [0.12, 0.67, 0.21, 0.18]
       },
       {
         "label": "human",
-        "probability": 0.008030000142753124
+        "probability": 0.008030000142753124,
+        "bounding_box": [0.26, 0.41, 0.35, 0.23]
       },
       {
         "label": "human",
-        "probability": 0.008999999612569809
+        "probability": 0.008999999612569809,
+        "bounding_box": [0.59, 0.52, 0.14, 0.31]
       },
       {
         "label": "human",
-        "probability": 0.013199999928474426
+        "probability": 0.013199999928474426,
+        "bounding_box": [0.44, 0.28, 0.29, 0.37]
       },
       {
         "label": "animal",
-        "probability": 0.022099999710917473
+        "probability": 0.022099999710917473,
+        "bounding_box": [0.18, 0.63, 0.32, 0.16]
       },
       {
         "label": "human",
-        "probability": 0.07010000199079514
+        "probability": 0.07010000199079514,
+        "bounding_box": [0.73, 0.19, 0.15, 0.44]
       },
       {
         "label": "human",
-        "probability": 0.08060000091791153
+        "probability": 0.08060000091791153,
+        "bounding_box": [0.31, 0.56, 0.27, 0.21]
       },
       {
         "label": "animal",
-        "probability": 0.14900000393390656
+        "probability": 0.14900000393390656,
+        "bounding_box": [0.48, 0.34, 0.24, 0.38]
       },
       {
         "label": "animal",
-        "probability": 0.6600000262260437
+        "probability": 0.6600000262260437,
+        "bounding_box": [0.62, 0.47, 0.19, 0.26]
       },
       {
         "label": "human",
-        "probability": 0.699999988079071
+        "probability": 0.699999988079071,
+        "bounding_box": [0.37, 0.21, 0.33, 0.41]
       }
     ],
     "image_store_delete_time": "2024-08-06T20:37:16.713024883+00:00",
@@ -252,7 +280,8 @@
     "score": [
       {
         "label": "animal",
-        "probability": 0.8429999947547913
+        "probability": 0.8429999947547913,
+        "bounding_box": [0.55, 0.39, 0.23, 0.32]
       }
     ],
     "image_store_delete_time": "2024-08-06T20:37:35.875405170+00:00",
@@ -269,7 +298,8 @@
     "score": [
       {
         "label": "animal",
-        "probability": 0.9409999847412109
+        "probability": 0.9409999847412109,
+        "bounding_box": [0.41, 0.26, 0.36, 0.28]
       }
     ],
     "image_store_delete_time": "2024-08-06T20:37:54.381557345+00:00",


### PR DESCRIPTION
This pull request introduces integrated experiment metrics computation into the Oracle CKN Daemon, enabling automatic calculation and streaming of comprehensive object detection metrics to Neo4j for each processed image event. The changes also update documentation and configuration to reflect the new unified service and metrics. The most important changes are grouped below:

**Experiment Metrics Integration:**

* Added experiment-level metrics computation to `daemon.py`, including precision, recall, F1 score, mean IoU, and mAP (mean average precision) at multiple thresholds. These metrics are calculated using both classification and detection (bounding box) data and are updated with each image event.
* Updated the event generation in `daemon.py` to include running experiment metrics in every event sent to Kafka/Neo4j, ensuring real-time metric updates for each image. [[1]](diffhunk://#diff-72ba995ff5f59199f4397da8828e7f04ab4a663b6357efd6ec050782b91ff581L112-R331) [[2]](diffhunk://#diff-72ba995ff5f59199f4397da8828e7f04ab4a663b6357efd6ec050782b91ff581L125-R357)

**Detection Data Support:**

* Modified event processing in `daemon.py` to handle ground truth bounding boxes and prediction bounding boxes, enabling detection-based metric computation.
* Updated sample event data in `image_mapping_final.json` to include `bounding_box` fields for predictions, supporting detection metrics. [[1]](diffhunk://#diff-db9eba2421042c60c7df0c87c911706b0ce44d7ba7a1827e7c718068e2af2a37L13-R14) [[2]](diffhunk://#diff-db9eba2421042c60c7df0c87c911706b0ce44d7ba7a1827e7c718068e2af2a37L30-R32)

**Documentation and Configuration Updates:**

* Revised `README.md` to describe the integrated service, usage instructions, and the new experiment metrics, with a clear breakdown of environment variables and metrics computed. [[1]](diffhunk://#diff-c942b91db1d98ffb662d5698f1de03e351c7853fad8f60014cc179c69af7b407R4-R19) [[2]](diffhunk://#diff-c942b91db1d98ffb662d5698f1de03e351c7853fad8f60014cc179c69af7b407L23-R30) [[3]](diffhunk://#diff-c942b91db1d98ffb662d5698f1de03e351c7853fad8f60014cc179c69af7b407L35-R76)
* Updated the Neo4j Cypher configuration in `neo4jsink-oracle-events-connector.json` to store experiment metrics on each event, supporting the new data model.

**Other Minor Improvements:**

* Changed the daemon Dockerfile to use `CMD` instead of `ENTRYPOINT` for more flexible container execution.
* Removed unused `numpy` dependency from dashboard requirements.

These changes collectively enhance the Oracle CKN Daemon to provide real-time, automated experiment metrics for object detection, improving monitoring and analysis capabilities for camera trap experiments.