### PR TITLE
Update Oracle CKN daemon configuration for Tapis Pods deployment

### DIFF
--- a/plugins/oracle_ckn_daemon/docker-compose.yml
+++ b/plugins/oracle_ckn_daemon/docker-compose.yml
@@ -7,11 +7,11 @@ services:
     environment:
       - ORACLE_CSV_PATH=/oracle_logs/image_mapping_final.json
       - CKN_LOG_FILE=/oracle_logs/ckn.log
-      - CKN_KAFKA_BROKER=broker:29092
+      - CKN_KAFKA_BROKER=cknbroker.pods.icicleai.tapis.io:443
       - CKN_KAFKA_TOPIC=oracle-events
       - CAMERA_TRAPS_DEVICE_ID=test-device
       - USER_ID=neelesh
-      - EXPERIMENT_ID=tapis-docker-power-test1
+      - EXPERIMENT_ID=tapis-pods-test
       - EXPERIMENT_END_SIGNAL=test-end-signal
       - POWER_SUMMARY_FILE=/power_logs/power_summary_report.json
       - POWER_SUMMARY_TOPIC=cameratraps-power-summary

--- a/plugins/oracle_ckn_daemon/oracle_daemon.py
+++ b/plugins/oracle_ckn_daemon/oracle_daemon.py
@@ -437,7 +437,7 @@ if __name__ == "__main__":
         time.sleep(1)
 
     # Configure Kafka producer.
-    kafka_conf = {'bootstrap.servers': KAFKA_BROKER, 'log_level': 0}
+    kafka_conf = {'bootstrap.servers': KAFKA_BROKER, 'log_level': 0, 'security.protocol': 'SSL'}
 
     logging.info("Connecting to the CKN broker at %s", KAFKA_BROKER)
 


### PR DESCRIPTION
## Summary

This PR updates the Oracle CKN daemon configuration to work with the Tapis Pods infrastructure.

## Changes

- **Kafka Configuration**: Updated broker endpoint from  to 
- **Security Protocol**: Added SSL security protocol to Kafka configuration for secure communication
- **Experiment ID**: Updated from  to  for production environment
- **Environment**: Configured for Tapis Pods production deployment

## Files Modified

- : Updated environment variables for Tapis Pods
- : Added SSL security protocol to Kafka configuration

## Testing

These changes configure the Oracle CKN daemon to work with the Tapis Pods infrastructure, enabling secure Kafka communication and proper experiment tracking.