### PR TITLE
Fix power monitoring test shutdown signal mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,13 @@ jobs:
 
           docker compose -f plugins/oracle_ckn_daemon/docker-compose.yml -f plugins/oracle_ckn_daemon/docker-compose.ci.yml up -d --build
           sleep 5
+          
+          # Trigger file modification - daemon will process events and detect shutdown signal
           docker exec ckn-oracle-daemon touch /oracle_logs/image_mapping_final.json
-          sleep 10
+          
+          # Wait for daemon to process shutdown signal and send power summary to Kafka -> Neo4j
+          echo "Waiting for power data ingestion..."
+          sleep 25
 
       - name: Test CKN Oracle Daemon plugin WITH power_monitoring
         run: |

--- a/plugins/oracle_ckn_daemon/docker-compose.yml
+++ b/plugins/oracle_ckn_daemon/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - CAMERA_TRAPS_DEVICE_ID=test-device
       - USER_ID=neelesh
       - EXPERIMENT_ID=tapis-pods-test
-      - EXPERIMENT_END_SIGNAL=test-end-signal
+      - EXPERIMENT_END_SIGNAL=6e153711-9823-4ee6-b608-58e2e801db51
       - POWER_SUMMARY_FILE=/power_logs/power_summary_report.json
       - POWER_SUMMARY_TOPIC=cameratraps-power-summary
       - ENABLE_POWER_MONITORING=false


### PR DESCRIPTION
## Summary
Fixes the power monitoring test failure where `total_cpu_power_consumption` and `total_gpu_power_consumption` properties were not found in the Deployment node.

## Root Cause
The `EXPERIMENT_END_SIGNAL` environment variable was set to `test-end-signal`, but the sample data (`image_mapping_final.json`) uses the UUID `6e153711-9823-4ee6-b608-58e2e801db51` as the shutdown signal.

This caused the daemon to:
1. Never detect the shutdown signal in the event data
2. Never call `process_summary_events()` to send power data to Kafka
3. Result in no power data being written to Neo4j

## Changes
- **docker-compose.yml**: Update `EXPERIMENT_END_SIGNAL` to match the UUID in sample data
- **ci.yml**: Increase wait time for power data pipeline (daemon shutdown → Kafka → Neo4j)

## Test plan
- [ ] Power monitoring test passes: `test_power_monitoring_true`
- [ ] Deployment node contains `total_cpu_power_consumption` and `total_gpu_power_consumption`